### PR TITLE
ADD logging enabled 4 EKS

### DIFF
--- a/eks.tf
+++ b/eks.tf
@@ -2,6 +2,7 @@ module "eks" {
   source       = "terraform-aws-modules/eks/aws"
   cluster_name = var.eks_cluster_name
   subnets      = module.vpc.private_subnets
+  cluster_enabled_log_types = var.eks-cw-logging
 
   tags = {
     Environment = var.env


### PR DESCRIPTION
I had the variable cluster_enabled_log_types to enabled EKS logging 
This variable is list type and you can add logging type you need to enable

`cluster_enabled_log_types= var.eks-cw-logging`